### PR TITLE
Feature/add support for old sdk apis

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/code
     docker:
-      - image: circleci/android:api-28-alpha
+      - image: circleci/android:api-29
     environment:
       JVM_OPTS: -Xmx3200m
     steps:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,11 +5,11 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     defaultConfig {
         applicationId "com.wizeline.viewstatesample"
-        minSdkVersion 21
-        targetSdkVersion 28
+        minSdkVersion 16
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,15 +5,18 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion sdk.compile
+
     defaultConfig {
         applicationId "com.wizeline.viewstatesample"
-        minSdkVersion 16
-        targetSdkVersion 29
+        minSdkVersion sdk.min
+        targetSdkVersion sdk.target
         versionCode 1
         versionName "1.0"
+        vectorDrawables.useSupportLibrary = true
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
+
     buildTypes {
         release {
             minifyEnabled false
@@ -29,15 +32,15 @@ dependencies {
     implementation project(path: ':viewstate')
 
     // Kotlin
-    implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'androidx.core:core-ktx:1.1.0'
+    implementation libraries.kotlin
 
     // Android
-    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation libraries.androidx.ktx
+    implementation libraries.androidx.appcompat
+    implementation libraries.androidx.recyclerView
 
     // Testing
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
-    implementation 'androidx.recyclerview:recyclerview:1.0.0'
+    testImplementation libraries.junit
+    androidTestImplementation libraries.runner
+    androidTestImplementation libraries.espressoCore
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 buildscript {
+    apply from: "libraries.gradle"
 
-    ext.kotlin_version = '1.3.50'
     repositories {
         google()
         jcenter()
-
     }
+
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     }
 }
 

--- a/libraries.gradle
+++ b/libraries.gradle
@@ -1,0 +1,39 @@
+ext {
+    sdk = [
+        compile: 29,
+        min: 16,
+        target: 29
+    ]
+    kotlinVersion = "1.3.72"
+
+    // Android libraries
+    appcompatVersion = "1.1.0"
+    ktxVersion = "1.3.0"
+    recyclerVersion = "1.1.0"
+
+    // Test
+    coreTestingVersion = "2.0.1"
+    runnerVersion = "1.1.1"
+    espressoVersion = '3.2.0'
+    junitVersion = '4.13'
+    junitExtVersion = '1.1.1'
+
+    // Implementations
+    libraries = [
+            kotlin: "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${kotlinVersion}",
+        // Test
+        junit: "junit:junit:${junitVersion}",
+        runner: "androidx.test:runner:${runnerVersion}",
+        espressoCore: "androidx.test.espresso:espresso-core:${espressoVersion}",
+        extJunit: "androidx.test.ext:junit:${junitExtVersion}",
+        extJunitKotlin: "androidx.test.ext:junit-ktx:${junitExtVersion}",
+        espressoIntents: "androidx.test.espresso:espresso-intents:${espressoVersion}",
+            testing: "androidx.arch.core:core-testing:$coreTestingVersion",
+        // Android libraries
+        androidx: [
+                ktx: "androidx.core:core-ktx:$ktxVersion",
+            appcompat: "androidx.appcompat:appcompat:${appcompatVersion}",
+            recyclerView: "androidx.recyclerview:recyclerview:${recyclerVersion}"
+        ]
+    ]
+}

--- a/libraries.gradle
+++ b/libraries.gradle
@@ -37,8 +37,7 @@ ext {
             recyclerView: "androidx.recyclerview:recyclerview:${recyclerVersion}"
         ],
             material       : [
-                    material: "com.google.android.material:material:${materialVersion}",
-                    design: "com.google.android.material:material:$designVersion"
+                    material: "com.google.android.material:material:${materialVersion}"
             ]
     ]
 }

--- a/libraries.gradle
+++ b/libraries.gradle
@@ -10,6 +10,7 @@ ext {
     appcompatVersion = "1.1.0"
     ktxVersion = "1.3.0"
     recyclerVersion = "1.1.0"
+    materialVersion = "1.1.0"
 
     // Test
     coreTestingVersion = "2.0.1"
@@ -34,6 +35,10 @@ ext {
                 ktx: "androidx.core:core-ktx:$ktxVersion",
             appcompat: "androidx.appcompat:appcompat:${appcompatVersion}",
             recyclerView: "androidx.recyclerview:recyclerview:${recyclerVersion}"
-        ]
+        ],
+            material       : [
+                    material: "com.google.android.material:material:${materialVersion}",
+                    design: "com.google.android.material:material:$designVersion"
+            ]
     ]
 }

--- a/viewstate/build.gradle
+++ b/viewstate/build.gradle
@@ -5,10 +5,10 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
 

--- a/viewstate/build.gradle
+++ b/viewstate/build.gradle
@@ -5,13 +5,15 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 29
-    defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 29
-        versionCode 1
-        versionName "1.0"
+    compileSdkVersion sdk.compile
 
+    defaultConfig {
+        minSdkVersion sdk.min
+        targetSdkVersion sdk.target
+        versionCode 2
+        versionName "1.0.1"
+
+        vectorDrawables.useSupportLibrary = true
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-rules.pro'
     }
@@ -26,13 +28,16 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    
+
     // Kotlin
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'androidx.core:core-ktx:1.1.0'
+    implementation libraries.kotlin
+
+    // Android
+    implementation libraries.androidx.ktx
+    implementation libraries.androidx.appcompat
 
     // Testing
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    testImplementation libraries.junit
+    androidTestImplementation libraries.runner
+    androidTestImplementation libraries.espressoCore
 }

--- a/viewstate/build.gradle
+++ b/viewstate/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     // Android
     implementation libraries.androidx.ktx
     implementation libraries.androidx.appcompat
+    implementation libraries.material.material
 
     // Testing
     testImplementation libraries.junit

--- a/viewstate/build.gradle
+++ b/viewstate/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'kotlin-android-extensions'
 android {
     compileSdkVersion 28
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 16
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"

--- a/viewstate/src/main/res/layout/view_state_empty.xml
+++ b/viewstate/src/main/res/layout/view_state_empty.xml
@@ -1,16 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:gravity="center"
     android:orientation="vertical">
 
-    <ImageView
+    <androidx.appcompat.widget.AppCompatImageView
         android:id="@+id/emptyImage"
         android:layout_width="@dimen/empty_state_image_size"
         android:layout_height="@dimen/empty_state_image_size"
         android:contentDescription="@null"
-        android:src="@drawable/ic_list"
+        app:srcCompat="@drawable/ic_list"
         android:layout_marginBottom="@dimen/offset_small"/>
 
     <TextView

--- a/viewstate/src/main/res/layout/view_state_error.xml
+++ b/viewstate/src/main/res/layout/view_state_error.xml
@@ -35,7 +35,7 @@
 
     <Button
         android:id="@+id/errorRetry"
-        style="@android:style/Widget.Material.Light.Button.Borderless.Colored"
+        style="@style/Button.Borderless.Colored"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/empty_state_error_retry"

--- a/viewstate/src/main/res/layout/view_state_error.xml
+++ b/viewstate/src/main/res/layout/view_state_error.xml
@@ -1,16 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:gravity="center"
     android:orientation="vertical">
 
-    <ImageView
+    <androidx.appcompat.widget.AppCompatImageView
         android:id="@+id/errorImage"
         android:layout_width="@dimen/empty_state_image_size"
         android:layout_height="@dimen/empty_state_image_size"
         android:contentDescription="@null"
-        android:src="@drawable/ic_wifi"
+        app:srcCompat="@drawable/ic_wifi"
         android:layout_marginBottom="@dimen/offset_small"/>
 
     <TextView

--- a/viewstate/src/main/res/layout/view_state_error.xml
+++ b/viewstate/src/main/res/layout/view_state_error.xml
@@ -35,7 +35,7 @@
 
     <Button
         android:id="@+id/errorRetry"
-        style="@android:style/Widget.Material.Button.Borderless.Colored"
+        style="@android:style/Widget.Material.Light.Button.Borderless.Colored"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/empty_state_error_retry"

--- a/viewstate/src/main/res/values-v21/styles.xml
+++ b/viewstate/src/main/res/values-v21/styles.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Button.Borderless.Colored" parent="android:Widget.Material.Button.Borderless.Colored" />
+</resources>

--- a/viewstate/src/main/res/values/styles.xml
+++ b/viewstate/src/main/res/values/styles.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Button.Borderless.Colored" parent="android:Widget.Holo.Button.Borderless" />
+</resources>


### PR DESCRIPTION
* Update minimum sdk api level to version 16 to enable support with old Android versions
* Add libraries file to manage versions and dependencies easier
* Add AppCompat to viewstate module to support vectors and update layouts to use compat components