### PR TITLE
fix setErrorRetryText method and adding tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:4.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Sep 24 12:09:16 CDT 2019
+#Wed Jan 27 09:20:52 CST 2021
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.1-bin.zip

--- a/libraries.gradle
+++ b/libraries.gradle
@@ -18,6 +18,8 @@ ext {
     espressoVersion = '3.2.0'
     junitVersion = '4.13'
     junitExtVersion = '1.1.1'
+    testVersion = "1.0.0"
+    robolectricVersion = "4.4"
 
     // Implementations
     libraries = [
@@ -30,6 +32,9 @@ ext {
         extJunitKotlin: "androidx.test.ext:junit-ktx:${junitExtVersion}",
         espressoIntents: "androidx.test.espresso:espresso-intents:${espressoVersion}",
             testing: "androidx.arch.core:core-testing:$coreTestingVersion",
+            testCore: "androidx.test:core:$testVersion",
+            rules: "androidx.test:rules:$testVersion",
+            robolectric: "org.robolectric:robolectric:$robolectricVersion",
         // Android libraries
         androidx: [
                 ktx: "androidx.core:core-ktx:$ktxVersion",

--- a/viewstate/build.gradle
+++ b/viewstate/build.gradle
@@ -24,6 +24,12 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
 }
 
 dependencies {
@@ -39,6 +45,10 @@ dependencies {
 
     // Testing
     testImplementation libraries.junit
+    testImplementation libraries.testCore
+    testImplementation libraries.runner
+    testImplementation libraries.extJunit
+    testImplementation libraries.robolectric
     androidTestImplementation libraries.runner
     androidTestImplementation libraries.espressoCore
 }

--- a/viewstate/src/main/java/com/wizeline/viewstate/ViewState.kt
+++ b/viewstate/src/main/java/com/wizeline/viewstate/ViewState.kt
@@ -124,7 +124,7 @@ class ViewState @JvmOverloads constructor(
      * Sets the error button text
      */
     fun setErrorRetryText(title: String) {
-        errorTitle.text = title
+        errorRetry.text = title
     }
 
     /**

--- a/viewstate/src/test/java/com/wizeline/viewstate/ViewStateTest.kt
+++ b/viewstate/src/test/java/com/wizeline/viewstate/ViewStateTest.kt
@@ -1,0 +1,159 @@
+package com.wizeline.viewstate
+
+import android.content.Context
+import android.os.Build
+import android.view.View
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.android.synthetic.main.view_state.view.*
+import kotlinx.android.synthetic.main.view_state_empty.view.*
+import kotlinx.android.synthetic.main.view_state_error.view.*
+import kotlinx.android.synthetic.main.view_state_loading.view.*
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Shadows
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [Build.VERSION_CODES.P])
+class ViewStateTest {
+    private lateinit var viewState: ViewState
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        viewState = ViewState(context)
+    }
+
+    @Test
+    fun setLoadingTitleText() {
+        val title = "the loading title"
+
+        viewState.setLoadingTitleText(title)
+
+        assertEquals(title, viewState.loadingTitle.text)
+    }
+
+    @Test
+    fun setEmptyImageResource() {
+        val imageResource = R.drawable.ic_list
+
+        viewState.setEmptyImageResource(imageResource)
+
+        assertEquals(
+            imageResource,
+            Shadows.shadowOf(viewState.emptyImage.drawable).createdFromResId
+        )
+    }
+
+    @Test
+    fun setEmptyTitleText() {
+        val title = "the empty title"
+
+        viewState.setEmptyTitleText(title)
+
+        assertEquals(title, viewState.emptyTitle.text)
+    }
+
+    @Test
+    fun setEmptyDescriptionText() {
+        val description = "empty description"
+
+        viewState.setEmptyDescriptionText(description)
+
+        assertEquals(description, viewState.emptyDescription.text)
+    }
+
+    @Test
+    fun setErrorImageResource() {
+        val imageResource = R.drawable.ic_list
+
+        viewState.setErrorImageResource(imageResource)
+
+        assertEquals(
+            imageResource,
+            Shadows.shadowOf(viewState.errorImage.drawable).createdFromResId
+        )
+    }
+
+    @Test
+    fun setErrorTitleText() {
+        val title = "error title"
+
+        viewState.setErrorTitleText(title)
+
+        assertEquals(title, viewState.errorTitle.text)
+    }
+
+    @Test
+    fun setErrorDescriptionText() {
+        val description = "error description"
+
+        viewState.setErrorDescriptionText(description)
+
+        assertEquals(description, viewState.errorDescription.text)
+    }
+
+    @Test
+    fun setErrorRetryText() {
+        val text = "error retry text"
+
+        viewState.setErrorRetryText(text)
+
+        assertEquals(text, viewState.errorRetry.text)
+    }
+
+    @Test
+    fun setOnRetryClickListener() {
+        var listenerIsCalled = false
+        val listener = { listenerIsCalled = true }
+
+        viewState.setOnRetryClickListener(listener)
+        viewState.errorRetry.performClick()
+
+        assertTrue(listenerIsCalled)
+    }
+
+    @Test
+    fun `setState for loading`() {
+        viewState.setState(State.LOADING)
+
+        assertEquals(View.VISIBLE, viewState.viewLoading.visibility)
+        assertEquals(View.GONE, viewState.viewEmpty.visibility)
+        assertEquals(View.GONE, viewState.viewError.visibility)
+        assertEquals(0, viewState.displayedChild)
+    }
+
+    @Test
+    fun `setState for content`() {
+        viewState.setState(State.CONTENT)
+
+        assertEquals(View.GONE, viewState.viewLoading.visibility)
+        assertEquals(View.GONE, viewState.viewEmpty.visibility)
+        assertEquals(View.GONE, viewState.viewError.visibility)
+        assertEquals(1, viewState.displayedChild)
+    }
+
+    @Test
+    fun `setState for empty`() {
+        viewState.setState(State.EMPTY)
+
+        assertEquals(View.VISIBLE, viewState.viewEmpty.visibility)
+        assertEquals(View.GONE, viewState.viewLoading.visibility)
+        assertEquals(View.GONE, viewState.viewError.visibility)
+        assertEquals(0, viewState.displayedChild)
+    }
+
+    @Test
+    fun `setState for error`() {
+        viewState.setState(State.ERROR)
+
+        assertEquals(View.VISIBLE, viewState.viewError.visibility)
+        assertEquals(View.GONE, viewState.viewLoading.visibility)
+        assertEquals(View.GONE, viewState.viewEmpty.visibility)
+        assertEquals(0, viewState.displayedChild)
+    }
+}


### PR DESCRIPTION
Hi 👋, I found a bug on the `setErrorRetryText` function. It is overriding the `errorTitle` text.
This PR fixes the bug and includes tests for the view =)

**Replication steps**
1. Add the following attributes to the ViewState in `activity_main.xml`
```
app:errorTitleText="The error title"
app:errorRetryText="Tap to retry"
```
2. Run the App
3. Tap the Action menu and select "Error"
Actual Result ------------------------- Expected Result
<img width="200" alt="Screen Shot 2021-01-27 at 10 20 53 a m" src="https://user-images.githubusercontent.com/2215585/106091670-82ef3900-60f2-11eb-8f33-b52259691963.png"><img width="200" alt="Screen Shot 2021-01-27 at 10 29 43 a m" src="https://user-images.githubusercontent.com/2215585/106091673-84b8fc80-60f2-11eb-9b7c-651ffbc977f8.png">
